### PR TITLE
Correct /all returns

### DIFF
--- a/backend/src/main/java/oi/feedain/backend/controllers/FeedbackController.java
+++ b/backend/src/main/java/oi/feedain/backend/controllers/FeedbackController.java
@@ -67,7 +67,7 @@ public class FeedbackController {
     public ResponseEntity getAllFeedback() {
         List<Feedback> feedbackList = this.feedbackService.getAllFeedback();
 
-        if (feedbackList.isEmpty()) return new ResponseEntity<>(new Response(feedbackList), HttpStatus.OK);
-        else return new ResponseEntity<>(new Response("No feedback found"), HttpStatus.OK);
+        if (feedbackList.isEmpty()) return new ResponseEntity<>(new Response("No feedback found", feedbackList), HttpStatus.OK);
+        else return new ResponseEntity<>(new Response(feedbackList), HttpStatus.OK);
     }
 }


### PR DESCRIPTION
So that it always returns the list and a message with it, when the list is empty. 